### PR TITLE
README and Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,18 @@
+.PHONY: run
+## run: runs the docker container for local development
+# the slack token is set to a dummy value of 1234, if you want to test the slack integration locally
+# you will need to update the environment variable parsed to the container
+# please do not commit the SLACK_TOKEN as this is a secret
+run:
+	docker build . -t slack-invite && docker run -e SLACK_TOKEN=1234 slack-invite
+
+.PHONY: test
+## test: runs all tests
+test:
+	go test ./...
+
+.PHONY: help
+## help: prints this help message
+help:
+	@echo "Usage: \n"
+	@sed -n 's/^##//p' ${MAKEFILE_LIST} | column -t -s ':' |  sed -e 's/^/ /'

--- a/README.md
+++ b/README.md
@@ -1,0 +1,11 @@
+# Slack Invite
+
+This repo is used for our slack invite mechanisme which helps us keep bots out of our slack channel.
+
+You can see it in action on [cloudnativenordics.com](https://cloudnativenordics.com)
+
+## How to contribute
+
+If you want to contribute you are very welcome.
+
+Start by writing `make help` in your terminal and this should get you started.


### PR DESCRIPTION
Make it easy to see what the project does and that contributions are welcome.
Added a makefile with a help command to make it easy to get started locally.

Also renamed the repo to: Slack-Invite
Because this is what the repo currently holds, if we expand it with more stuff we can figure out if we want another repo or want to do a mono repo for all backend stuff.